### PR TITLE
Add image placeholders to What we do cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,16 +121,25 @@
 
     <div class="mt-8 grid gap-6 md:grid-cols-3">
       <div class="card p-6">
+        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
+          Image placeholder
+        </div>
         <div class="pill mb-3">AI Software</div>
         <h3 class="font-medium">LLM apps, retrieval, automation</h3>
         <p class="mt-2 text-sm text-zinc-700">RAG pipelines, evals, agents, data infra.</p>
       </div>
       <div class="card p-6">
+        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
+          Image placeholder
+        </div>
         <div class="pill mb-3">Web Design & Build</div>
         <h3 class="font-medium">Design systems, Next.js, Webflow, Shopify</h3>
         <p class="mt-2 text-sm text-zinc-700">From tokens to component libraries to shipped sites.</p>
       </div>
       <div class="card p-6">
+        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
+          Image placeholder
+        </div>
         <div class="pill mb-3">Performance & DX</div>
         <h3 class="font-medium">Core Web Vitals, accessibility, CI/CD</h3>
         <p class="mt-2 text-sm text-zinc-700">Regression checks, tabular metrics, clean handoffs.</p>

--- a/public/index.html
+++ b/public/index.html
@@ -121,16 +121,25 @@
 
     <div class="mt-8 grid gap-6 md:grid-cols-3">
       <div class="card p-6">
+        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
+          Image placeholder
+        </div>
         <div class="pill mb-3">AI Software</div>
         <h3 class="font-medium">LLM apps, retrieval, automation</h3>
         <p class="mt-2 text-sm text-zinc-700">RAG pipelines, evals, agents, data infra.</p>
       </div>
       <div class="card p-6">
+        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
+          Image placeholder
+        </div>
         <div class="pill mb-3">Web Design & Build</div>
         <h3 class="font-medium">Design systems, Next.js, Webflow, Shopify</h3>
         <p class="mt-2 text-sm text-zinc-700">From tokens to component libraries to shipped sites.</p>
       </div>
       <div class="card p-6">
+        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
+          Image placeholder
+        </div>
         <div class="pill mb-3">Performance & DX</div>
         <h3 class="font-medium">Core Web Vitals, accessibility, CI/CD</h3>
         <p class="mt-2 text-sm text-zinc-700">Regression checks, tabular metrics, clean handoffs.</p>


### PR DESCRIPTION
## Summary
- add neutral placeholder blocks to each What we do service card so images can be added later

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0387922a48326ae829f00d7abfcc7