### PR TITLE
Add redirecting index for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lakeshore Design</title>
+    <meta http-equiv="refresh" content="0; url=./docs/index.html" />
+    <link rel="canonical" href="./docs/index.html" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        margin: 0;
+        background: #f8fafc;
+        color: #1f2937;
+      }
+      .message {
+        text-align: center;
+        max-width: 32rem;
+        padding: 2rem;
+      }
+      .message h1 {
+        font-size: 1.5rem;
+        margin-bottom: 0.75rem;
+      }
+      .message a {
+        color: #3552a3;
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .message a:hover {
+        text-decoration: underline;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="message">
+      <h1>Redirecting to the Lakeshore homepage…</h1>
+      <p>If you are not redirected automatically, <a href="./docs/index.html">click here to open the site</a>.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a root-level HTML redirect so visiting the repository root forwards to the published docs homepage
- include a minimal fallback message with a manual link to the Lakeshore site if the redirect does not fire

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e0391a94148326a2f9f82c112e8f1e