### PR TITLE
Remove Why Lakeshore section from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,29 +171,6 @@
     </div>
   </section>
 
-  <hr class="my-12 md:my-16"/>
-
-  <!-- Differentiators -->
-  <section class="mx-auto max-w-6xl px-4">
-    <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Why Lakeshore</h2>
-    <ul class="mt-6 grid gap-4 md:grid-cols-3 text-sm">
-      <li class="card p-5">
-        <h3 class="font-medium">System design</h3>
-        <p class="mt-1 text-zinc-700">Tokens → components → repos. Drift stays at zero.</p>
-      </li>
-      <li class="card p-5">
-        <h3 class="font-medium">Performance discipline</h3>
-        <p class="mt-1 text-zinc-700">Core Web Vitals, regression checks, tabular metrics.</p>
-      </li>
-      <li class="card p-5">
-        <h3 class="font-medium">Calm delivery</h3>
-        <p class="mt-1 text-zinc-700">Clear scope, clean handoffs, documentation.</p>
-      </li>
-    </ul>
-  </section>
-
-  <hr class="my-12 md:my-16"/>
-
   <!-- Approach -->
   <section id="approach" class="mx-auto max-w-6xl px-4">
     <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Approach</h2>

--- a/public/index.html
+++ b/public/index.html
@@ -171,29 +171,6 @@
     </div>
   </section>
 
-  <hr class="my-12 md:my-16"/>
-
-  <!-- Differentiators -->
-  <section class="mx-auto max-w-6xl px-4">
-    <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Why Lakeshore</h2>
-    <ul class="mt-6 grid gap-4 md:grid-cols-3 text-sm">
-      <li class="card p-5">
-        <h3 class="font-medium">System design</h3>
-        <p class="mt-1 text-zinc-700">Tokens → components → repos. Drift stays at zero.</p>
-      </li>
-      <li class="card p-5">
-        <h3 class="font-medium">Performance discipline</h3>
-        <p class="mt-1 text-zinc-700">Core Web Vitals, regression checks, tabular metrics.</p>
-      </li>
-      <li class="card p-5">
-        <h3 class="font-medium">Calm delivery</h3>
-        <p class="mt-1 text-zinc-700">Clear scope, clean handoffs, documentation.</p>
-      </li>
-    </ul>
-  </section>
-
-  <hr class="my-12 md:my-16"/>
-
   <!-- Approach -->
   <section id="approach" class="mx-auto max-w-6xl px-4">
     <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Approach</h2>


### PR DESCRIPTION
## Summary
- remove the "Why Lakeshore" differentiators block from the homepage markup
- delete the surrounding divider so the layout flows directly into the Approach section

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e03de84e4483268ef4247130fa1695