### PR TITLE
Add HTML schematics for service cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -121,24 +121,91 @@
 
     <div class="mt-8 grid gap-6 md:grid-cols-3">
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="relative mx-auto flex h-full w-full max-w-[9rem] items-center justify-center">
+            <div class="relative h-full w-full">
+              <div class="absolute inset-0 rounded-full border-2 border-indigo-500/70"></div>
+              <div class="absolute left-1/2 top-0 h-6 w-px -translate-x-1/2 bg-indigo-500/70"></div>
+              <div class="absolute right-0 top-1/2 h-px w-6 -translate-y-1/2 bg-indigo-500/70"></div>
+              <div class="absolute bottom-0 left-1/2 h-6 w-px -translate-x-1/2 bg-indigo-500/70"></div>
+              <div class="absolute left-0 top-1/2 h-px w-6 -translate-y-1/2 bg-indigo-500/70"></div>
+              <div class="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 rounded border border-indigo-500 bg-indigo-500/10"></div>
+              <div class="absolute left-1/2 top-[18%] -translate-x-1/2 rounded-full border border-indigo-500 bg-white/60 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-600">AI</div>
+              <div class="absolute left-1/2 top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute right-0 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute bottom-0 left-1/2 h-2 w-2 -translate-x-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute left-0 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-indigo-500"></div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">AI Software</div>
         <h3 class="font-medium">LLM apps, retrieval, automation</h3>
         <p class="mt-2 text-sm text-zinc-700">RAG pipelines, evals, agents, data infra.</p>
       </div>
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="flex h-full w-full flex-col gap-3">
+            <div class="h-3 rounded bg-emerald-500/80"></div>
+            <div class="flex flex-1 gap-3">
+              <div class="flex w-1/2 flex-col gap-2">
+                <div class="h-12 rounded border border-emerald-500/70 bg-emerald-500/10"></div>
+                <div class="flex gap-2">
+                  <div class="h-10 flex-1 rounded border border-emerald-400/60"></div>
+                  <div class="h-10 flex-1 rounded border border-emerald-400/60"></div>
+                </div>
+              </div>
+              <div class="flex w-1/2 flex-col gap-2">
+                <div class="h-6 rounded border border-emerald-400/70 bg-white"></div>
+                <div class="flex flex-1 flex-col gap-2">
+                  <div class="flex-1 rounded border border-emerald-400/60 bg-emerald-500/5"></div>
+                  <div class="flex flex-1 items-end gap-2">
+                    <div class="h-6 w-1/3 rounded bg-emerald-500/80"></div>
+                    <div class="h-8 w-1/3 rounded bg-emerald-500/60"></div>
+                    <div class="h-10 w-1/3 rounded bg-emerald-500/40"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">Web Design & Build</div>
         <h3 class="font-medium">Design systems, Next.js, Webflow, Shopify</h3>
         <p class="mt-2 text-sm text-zinc-700">From tokens to component libraries to shipped sites.</p>
       </div>
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex items-center justify-between text-[11px] font-medium uppercase tracking-wide text-amber-600">
+              <span>DX</span>
+              <span>Performance</span>
+            </div>
+            <div class="relative flex flex-1 items-end gap-2">
+              <div class="absolute inset-x-0 bottom-0 h-px bg-amber-500/50"></div>
+              <div class="flex h-12 w-full items-end gap-1">
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-3 w-full rounded bg-amber-400/70"></div>
+                  <div class="absolute -top-3 right-1 text-[10px] font-semibold text-amber-600">95</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-6 w-full rounded bg-amber-400/80"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">98</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-9 w-full rounded bg-amber-400"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">100</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-7 w-full rounded bg-amber-400/90"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">99</div>
+                </div>
+              </div>
+            </div>
+            <div class="grid grid-cols-3 gap-2 text-[10px] text-amber-700">
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">CWV</div>
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">CI/CD</div>
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">A11y</div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">Performance & DX</div>
         <h3 class="font-medium">Core Web Vitals, accessibility, CI/CD</h3>

--- a/index.html
+++ b/index.html
@@ -121,24 +121,91 @@
 
     <div class="mt-8 grid gap-6 md:grid-cols-3">
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="relative mx-auto flex h-full w-full max-w-[9rem] items-center justify-center">
+            <div class="relative h-full w-full">
+              <div class="absolute inset-0 rounded-full border-2 border-indigo-500/70"></div>
+              <div class="absolute left-1/2 top-0 h-6 w-px -translate-x-1/2 bg-indigo-500/70"></div>
+              <div class="absolute right-0 top-1/2 h-px w-6 -translate-y-1/2 bg-indigo-500/70"></div>
+              <div class="absolute bottom-0 left-1/2 h-6 w-px -translate-x-1/2 bg-indigo-500/70"></div>
+              <div class="absolute left-0 top-1/2 h-px w-6 -translate-y-1/2 bg-indigo-500/70"></div>
+              <div class="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 rounded border border-indigo-500 bg-indigo-500/10"></div>
+              <div class="absolute left-1/2 top-[18%] -translate-x-1/2 rounded-full border border-indigo-500 bg-white/60 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-600">AI</div>
+              <div class="absolute left-1/2 top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute right-0 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute bottom-0 left-1/2 h-2 w-2 -translate-x-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute left-0 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-indigo-500"></div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">AI Software</div>
         <h3 class="font-medium">LLM apps, retrieval, automation</h3>
         <p class="mt-2 text-sm text-zinc-700">RAG pipelines, evals, agents, data infra.</p>
       </div>
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="flex h-full w-full flex-col gap-3">
+            <div class="h-3 rounded bg-emerald-500/80"></div>
+            <div class="flex flex-1 gap-3">
+              <div class="flex w-1/2 flex-col gap-2">
+                <div class="h-12 rounded border border-emerald-500/70 bg-emerald-500/10"></div>
+                <div class="flex gap-2">
+                  <div class="h-10 flex-1 rounded border border-emerald-400/60"></div>
+                  <div class="h-10 flex-1 rounded border border-emerald-400/60"></div>
+                </div>
+              </div>
+              <div class="flex w-1/2 flex-col gap-2">
+                <div class="h-6 rounded border border-emerald-400/70 bg-white"></div>
+                <div class="flex flex-1 flex-col gap-2">
+                  <div class="flex-1 rounded border border-emerald-400/60 bg-emerald-500/5"></div>
+                  <div class="flex flex-1 items-end gap-2">
+                    <div class="h-6 w-1/3 rounded bg-emerald-500/80"></div>
+                    <div class="h-8 w-1/3 rounded bg-emerald-500/60"></div>
+                    <div class="h-10 w-1/3 rounded bg-emerald-500/40"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">Web Design & Build</div>
         <h3 class="font-medium">Design systems, Next.js, Webflow, Shopify</h3>
         <p class="mt-2 text-sm text-zinc-700">From tokens to component libraries to shipped sites.</p>
       </div>
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex items-center justify-between text-[11px] font-medium uppercase tracking-wide text-amber-600">
+              <span>DX</span>
+              <span>Performance</span>
+            </div>
+            <div class="relative flex flex-1 items-end gap-2">
+              <div class="absolute inset-x-0 bottom-0 h-px bg-amber-500/50"></div>
+              <div class="flex h-12 w-full items-end gap-1">
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-3 w-full rounded bg-amber-400/70"></div>
+                  <div class="absolute -top-3 right-1 text-[10px] font-semibold text-amber-600">95</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-6 w-full rounded bg-amber-400/80"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">98</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-9 w-full rounded bg-amber-400"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">100</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-7 w-full rounded bg-amber-400/90"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">99</div>
+                </div>
+              </div>
+            </div>
+            <div class="grid grid-cols-3 gap-2 text-[10px] text-amber-700">
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">CWV</div>
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">CI/CD</div>
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">A11y</div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">Performance & DX</div>
         <h3 class="font-medium">Core Web Vitals, accessibility, CI/CD</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -121,24 +121,91 @@
 
     <div class="mt-8 grid gap-6 md:grid-cols-3">
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="relative mx-auto flex h-full w-full max-w-[9rem] items-center justify-center">
+            <div class="relative h-full w-full">
+              <div class="absolute inset-0 rounded-full border-2 border-indigo-500/70"></div>
+              <div class="absolute left-1/2 top-0 h-6 w-px -translate-x-1/2 bg-indigo-500/70"></div>
+              <div class="absolute right-0 top-1/2 h-px w-6 -translate-y-1/2 bg-indigo-500/70"></div>
+              <div class="absolute bottom-0 left-1/2 h-6 w-px -translate-x-1/2 bg-indigo-500/70"></div>
+              <div class="absolute left-0 top-1/2 h-px w-6 -translate-y-1/2 bg-indigo-500/70"></div>
+              <div class="absolute left-1/2 top-1/2 h-8 w-8 -translate-x-1/2 -translate-y-1/2 rounded border border-indigo-500 bg-indigo-500/10"></div>
+              <div class="absolute left-1/2 top-[18%] -translate-x-1/2 rounded-full border border-indigo-500 bg-white/60 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-600">AI</div>
+              <div class="absolute left-1/2 top-0 h-2 w-2 -translate-x-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute right-0 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute bottom-0 left-1/2 h-2 w-2 -translate-x-1/2 rounded-full bg-indigo-500"></div>
+              <div class="absolute left-0 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full bg-indigo-500"></div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">AI Software</div>
         <h3 class="font-medium">LLM apps, retrieval, automation</h3>
         <p class="mt-2 text-sm text-zinc-700">RAG pipelines, evals, agents, data infra.</p>
       </div>
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="flex h-full w-full flex-col gap-3">
+            <div class="h-3 rounded bg-emerald-500/80"></div>
+            <div class="flex flex-1 gap-3">
+              <div class="flex w-1/2 flex-col gap-2">
+                <div class="h-12 rounded border border-emerald-500/70 bg-emerald-500/10"></div>
+                <div class="flex gap-2">
+                  <div class="h-10 flex-1 rounded border border-emerald-400/60"></div>
+                  <div class="h-10 flex-1 rounded border border-emerald-400/60"></div>
+                </div>
+              </div>
+              <div class="flex w-1/2 flex-col gap-2">
+                <div class="h-6 rounded border border-emerald-400/70 bg-white"></div>
+                <div class="flex flex-1 flex-col gap-2">
+                  <div class="flex-1 rounded border border-emerald-400/60 bg-emerald-500/5"></div>
+                  <div class="flex flex-1 items-end gap-2">
+                    <div class="h-6 w-1/3 rounded bg-emerald-500/80"></div>
+                    <div class="h-8 w-1/3 rounded bg-emerald-500/60"></div>
+                    <div class="h-10 w-1/3 rounded bg-emerald-500/40"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">Web Design & Build</div>
         <h3 class="font-medium">Design systems, Next.js, Webflow, Shopify</h3>
         <p class="mt-2 text-sm text-zinc-700">From tokens to component libraries to shipped sites.</p>
       </div>
       <div class="card p-6">
-        <div class="mb-4 flex h-40 w-full items-center justify-center rounded bg-zinc-200 text-sm text-zinc-500">
-          Image placeholder
+        <div class="mb-4 h-40 w-full rounded border border-zinc-200 bg-white p-4">
+          <div class="flex h-full w-full flex-col justify-between">
+            <div class="flex items-center justify-between text-[11px] font-medium uppercase tracking-wide text-amber-600">
+              <span>DX</span>
+              <span>Performance</span>
+            </div>
+            <div class="relative flex flex-1 items-end gap-2">
+              <div class="absolute inset-x-0 bottom-0 h-px bg-amber-500/50"></div>
+              <div class="flex h-12 w-full items-end gap-1">
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-3 w-full rounded bg-amber-400/70"></div>
+                  <div class="absolute -top-3 right-1 text-[10px] font-semibold text-amber-600">95</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-6 w-full rounded bg-amber-400/80"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">98</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-9 w-full rounded bg-amber-400"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">100</div>
+                </div>
+                <div class="relative flex-1">
+                  <div class="absolute bottom-0 h-7 w-full rounded bg-amber-400/90"></div>
+                  <div class="absolute -top-4 right-1 text-[10px] font-semibold text-amber-600">99</div>
+                </div>
+              </div>
+            </div>
+            <div class="grid grid-cols-3 gap-2 text-[10px] text-amber-700">
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">CWV</div>
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">CI/CD</div>
+              <div class="rounded border border-amber-500/60 bg-amber-500/10 px-2 py-1 text-center">A11y</div>
+            </div>
+          </div>
         </div>
         <div class="pill mb-3">Performance & DX</div>
         <h3 class="font-medium">Core Web Vitals, accessibility, CI/CD</h3>


### PR DESCRIPTION
## Summary
- replace generic service placeholders with HTML schematics that suggest each offering
- mirror the updated schematics across the public and docs builds for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e040f5ebd48326ad38bee0ce13892f