### PR TITLE
Adjust brand and word mark layout

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -19,16 +19,16 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/#services">Services</a>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -19,16 +19,16 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/#services">Services</a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -19,16 +19,16 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/#services">Services</a>

--- a/docs/blog/post-template.html
+++ b/docs/blog/post-template.html
@@ -19,16 +19,16 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/#services">Services</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,20 +21,19 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="#" class="flex items-center gap-2">
+          <span class="font-tight text-lg tracking-tight">Lakeshore</span>
           <!-- Brand mark (inherits color from the text color via currentColor) -->
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <!-- Filled circle uses currentColor so we can theme via Tailwind -->
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <!-- Wave cutout (stays white for contrast) -->
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
-<span class="font-tight text-lg tracking-tight">Lakeshore</span>
-
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <!-- Filled circle uses currentColor so we can theme via Tailwind -->
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <!-- Wave cutout (stays white for contrast) -->
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="#services">Services</a>

--- a/index.html
+++ b/index.html
@@ -21,20 +21,19 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
+          <span class="font-tight text-lg tracking-tight">Lakeshore</span>
           <!-- Brand mark (inherits color from the text color via currentColor) -->
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <!-- Filled circle uses currentColor so we can theme via Tailwind -->
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <!-- Wave cutout (stays white for contrast) -->
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
-<span class="font-tight text-lg tracking-tight">Lakeshore</span>
-
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <!-- Filled circle uses currentColor so we can theme via Tailwind -->
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <!-- Wave cutout (stays white for contrast) -->
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="#services">Services</a>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -19,16 +19,16 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/#services">Services</a>

--- a/public/blog/post-template.html
+++ b/public/blog/post-template.html
@@ -19,16 +19,16 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/#services">Services</a>

--- a/public/index.html
+++ b/public/index.html
@@ -21,20 +21,19 @@
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
         <a href="/" class="flex items-center gap-2">
+          <span class="font-tight text-lg tracking-tight">Lakeshore</span>
           <!-- Brand mark (inherits color from the text color via currentColor) -->
-<svg class="h-6 w-6 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
-  <!-- Filled circle uses currentColor so we can theme via Tailwind -->
-  <circle cx="50" cy="50" r="48" fill="currentColor"/>
-  <!-- Wave cutout (stays white for contrast) -->
-  <path d="M20 55 Q40 45, 60 55 T100 55"
-        fill="none"
-        stroke="white"
-        stroke-width="8"
-        stroke-linecap="round"
-        stroke-linejoin="round"/>
-</svg>
-<span class="font-tight text-lg tracking-tight">Lakeshore</span>
-
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+            <!-- Filled circle uses currentColor so we can theme via Tailwind -->
+            <circle cx="50" cy="50" r="48" fill="currentColor"/>
+            <!-- Wave cutout (stays white for contrast) -->
+            <path d="M20 55 Q40 45, 60 55 T100 55"
+                  fill="none"
+                  stroke="white"
+                  stroke-width="8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"/>
+          </svg>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="#services">Services</a>


### PR DESCRIPTION
## Summary
- reorder the header brand assets so the Lakeshore word mark precedes the circular brand mark across the site
- resize the brand mark SVG to a smaller, balanced scale relative to the word mark

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e05dbf610483268de7aff732b3dbbd