### PR TITLE
Remove Services, Work, and Approach links from navigation

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -31,9 +31,6 @@
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="/#services">Services</a>
-          <a class="hover:text-deep-lake" href="/#work">Work</a>
-          <a class="hover:text-deep-lake" href="/#approach">Approach</a>
           <a class="hover:text-deep-lake text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
@@ -43,9 +40,6 @@
     </div>
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#approach">Approach</a>
         <a class="px-2 py-2 rounded bg-mist text-deep-lake" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -31,9 +31,6 @@
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="/#services">Services</a>
-          <a class="hover:text-deep-lake" href="/#work">Work</a>
-          <a class="hover:text-deep-lake" href="/#approach">Approach</a>
           <a class="hover:text-deep-lake text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
@@ -43,9 +40,6 @@
     </div>
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#approach">Approach</a>
         <a class="px-2 py-2 rounded bg-mist text-deep-lake" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -31,9 +31,6 @@
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="/#services">Services</a>
-          <a class="hover:text-deep-lake" href="/#work">Work</a>
-          <a class="hover:text-deep-lake" href="/#approach">Approach</a>
           <a class="hover:text-deep-lake text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
@@ -43,9 +40,6 @@
     </div>
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#approach">Approach</a>
         <a class="px-2 py-2 rounded bg-mist text-deep-lake" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>

--- a/docs/blog/post-template.html
+++ b/docs/blog/post-template.html
@@ -31,9 +31,6 @@
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="/#services">Services</a>
-          <a class="hover:text-deep-lake" href="/#work">Work</a>
-          <a class="hover:text-deep-lake" href="/#approach">Approach</a>
           <a class="hover:text-deep-lake text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
@@ -43,9 +40,6 @@
     </div>
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#approach">Approach</a>
         <a class="px-2 py-2 rounded bg-mist text-deep-lake" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,9 +37,6 @@
 
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="#services">Services</a>
-          <a class="hover:text-deep-lake" href="#work">Work</a>
-          <a class="hover:text-deep-lake" href="#approach">Approach</a>
           <a class="hover:text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="#contact">Start a project</a>
@@ -50,9 +47,6 @@
     <!-- Mobile menu -->
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#approach">Approach</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="#contact">Start a project</a>

--- a/index.html
+++ b/index.html
@@ -37,9 +37,6 @@
 
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="#services">Services</a>
-          <a class="hover:text-deep-lake" href="#work">Work</a>
-          <a class="hover:text-deep-lake" href="#approach">Approach</a>
           <a class="hover:text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="#contact">Start a project</a>
@@ -50,9 +47,6 @@
     <!-- Mobile menu -->
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#approach">Approach</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="#contact">Start a project</a>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -31,9 +31,6 @@
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="/#services">Services</a>
-          <a class="hover:text-deep-lake" href="/#work">Work</a>
-          <a class="hover:text-deep-lake" href="/#approach">Approach</a>
           <a class="hover:text-deep-lake text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
@@ -43,9 +40,6 @@
     </div>
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#approach">Approach</a>
         <a class="px-2 py-2 rounded bg-mist text-deep-lake" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>

--- a/public/blog/post-template.html
+++ b/public/blog/post-template.html
@@ -31,9 +31,6 @@
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="/#services">Services</a>
-          <a class="hover:text-deep-lake" href="/#work">Work</a>
-          <a class="hover:text-deep-lake" href="/#approach">Approach</a>
           <a class="hover:text-deep-lake text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
@@ -43,9 +40,6 @@
     </div>
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="/#approach">Approach</a>
         <a class="px-2 py-2 rounded bg-mist text-deep-lake" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>

--- a/public/index.html
+++ b/public/index.html
@@ -37,9 +37,6 @@
 
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a class="hover:text-deep-lake" href="#services">Services</a>
-          <a class="hover:text-deep-lake" href="#work">Work</a>
-          <a class="hover:text-deep-lake" href="#approach">Approach</a>
           <a class="hover:text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="#contact">Contact</a>
           <a class="btn btn-primary ml-2" href="#contact">Start a project</a>
@@ -50,9 +47,6 @@
     <!-- Mobile menu -->
     <div id="mobileNav" class="md:hidden hidden border-t border-hairline">
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#services">Services</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#work">Work</a>
-        <a class="px-2 py-2 rounded hover:bg-mist" href="#approach">Approach</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="#contact">Contact</a>
         <a class="btn btn-primary mt-1 w-full" href="#contact">Start a project</a>


### PR DESCRIPTION
## Summary
- remove the Services, Work, and Approach links from the desktop navigation across the main and blog pages
- update the mobile navigation menus to match the simplified link set

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e05de24bdc832689f18d882c892fc3