### PR TITLE
Adjust blog hero padding for better spacing

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -58,7 +58,7 @@
       <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-      <div class="mx-auto max-w-4xl px-4 py-16 md:py-24">
+      <div class="mx-auto max-w-4xl px-4 pt-24 pb-24 md:pt-32 md:pb-28">
         <p class="pill">Lakeshore Notebook</p>
         <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
         <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>

--- a/blog/post-template.html
+++ b/blog/post-template.html
@@ -59,7 +59,7 @@
         <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
         <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
         <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-        <div class="mx-auto max-w-3xl px-4 py-16 md:py-24">
+        <div class="mx-auto max-w-3xl px-4 pt-24 pb-24 md:pt-32 md:pb-28">
           <a href="/blog/" class="pill hover:border-deep-lake hover:text-deep-lake">← Back to all posts</a>
           <p class="mt-6 text-sm uppercase tracking-wide text-zinc-500">Case Study · Feb 2025</p>
           <h1 class="mt-3 font-tight text-4xl md:text-5xl tracking-tight">Shipping a resilient retrieval pipeline in 10 days</h1>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -58,7 +58,7 @@
       <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-      <div class="mx-auto max-w-4xl px-4 py-16 md:py-24">
+      <div class="mx-auto max-w-4xl px-4 pt-24 pb-24 md:pt-32 md:pb-28">
         <p class="pill">Lakeshore Notebook</p>
         <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
         <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>

--- a/docs/blog/post-template.html
+++ b/docs/blog/post-template.html
@@ -59,7 +59,7 @@
         <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
         <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
         <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-        <div class="mx-auto max-w-3xl px-4 py-16 md:py-24">
+        <div class="mx-auto max-w-3xl px-4 pt-24 pb-24 md:pt-32 md:pb-28">
           <a href="/blog/" class="pill hover:border-deep-lake hover:text-deep-lake">← Back to all posts</a>
           <p class="mt-6 text-sm uppercase tracking-wide text-zinc-500">Case Study · Feb 2025</p>
           <h1 class="mt-3 font-tight text-4xl md:text-5xl tracking-tight">Shipping a resilient retrieval pipeline in 10 days</h1>

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -58,7 +58,7 @@
       <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-      <div class="mx-auto max-w-4xl px-4 py-16 md:py-24">
+      <div class="mx-auto max-w-4xl px-4 pt-24 pb-24 md:pt-32 md:pb-28">
         <p class="pill">Lakeshore Notebook</p>
         <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
         <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>

--- a/public/blog/post-template.html
+++ b/public/blog/post-template.html
@@ -59,7 +59,7 @@
         <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
         <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
         <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-        <div class="mx-auto max-w-3xl px-4 py-16 md:py-24">
+        <div class="mx-auto max-w-3xl px-4 pt-24 pb-24 md:pt-32 md:pb-28">
           <a href="/blog/" class="pill hover:border-deep-lake hover:text-deep-lake">← Back to all posts</a>
           <p class="mt-6 text-sm uppercase tracking-wide text-zinc-500">Case Study · Feb 2025</p>
           <h1 class="mt-3 font-tight text-4xl md:text-5xl tracking-tight">Shipping a resilient retrieval pipeline in 10 days</h1>


### PR DESCRIPTION
## Summary
- increase the blog index hero padding to provide more clearance below the sticky header across breakpoints
- mirror the same spacing update in the post template and the generated public/docs copies to keep everything in sync

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e05e2575688326b7318e6f56024b02