### PR TITLE
Align blog hero with main grid

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -52,10 +52,12 @@
       <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-      <div class="mx-auto max-w-4xl px-4 py-16 md:py-24">
-        <p class="pill">Lakeshore Notebook</p>
-        <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
-        <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>
+      <div class="mx-auto max-w-6xl px-4 py-16 md:py-24">
+        <div class="mx-auto max-w-3xl">
+          <p class="pill">Lakeshore Notebook</p>
+          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
+          <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>
+        </div>
       </div>
     </section>
 

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -52,10 +52,12 @@
       <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-      <div class="mx-auto max-w-4xl px-4 py-16 md:py-24">
-        <p class="pill">Lakeshore Notebook</p>
-        <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
-        <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>
+      <div class="mx-auto max-w-6xl px-4 py-16 md:py-24">
+        <div class="mx-auto max-w-3xl">
+          <p class="pill">Lakeshore Notebook</p>
+          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
+          <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>
+        </div>
       </div>
     </section>
 

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -52,10 +52,12 @@
       <div class="absolute inset-0 -z-10 bg-gradient-to-b from-mist via-white/70 to-snow"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
-      <div class="mx-auto max-w-4xl px-4 py-16 md:py-24">
-        <p class="pill">Lakeshore Notebook</p>
-        <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
-        <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>
+      <div class="mx-auto max-w-6xl px-4 py-16 md:py-24">
+        <div class="mx-auto max-w-3xl">
+          <p class="pill">Lakeshore Notebook</p>
+          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Ideas from the shop floor.</h1>
+          <p class="mt-5 text-lg text-zinc-700 max-w-2xl">Deep dives on AI systems, process, and the craft decisions that keep software steady. New posts drop as we ship notable work.</p>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- widen the blog hero container to match the main grid while keeping text width constrained
- mirror the updated hero markup in the generated public and docs copies

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e0619a50788326b7420cc5423d24d3