### PR TITLE
Restore header logo spacing and sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
   <header class="sticky top-0 z-50 bg-snow/80 backdrop-blur supports-[backdrop-filter]:bg-snow/60 border-b border-hairline">
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex h-14 items-center justify-between">
-        <a href="/" class="flex items-center gap-1">
+        <a href="/" class="flex items-center gap-2">
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
           <!-- Brand mark (inherits color from the text color via currentColor) -->
-          <svg class="h-4 w-4 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
             <!-- Filled circle uses currentColor so we can theme via Tailwind -->
             <circle cx="50" cy="50" r="48" fill="currentColor"/>
             <!-- Wave cutout (stays white for contrast) -->


### PR DESCRIPTION
## Summary
- restore the header logo spacing by reverting the link gap to the original value
- resize the brand mark SVG back to its previous dimensions for better visibility

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e071c0d83883268539f47f8b3b069d