### PR TITLE
Remove period from hero heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
       <div class="max-w-prose">
         <p class="pill">Made in Chicago</p>
         <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">
-          Engineering-grade systems for AI and the web.
+          Engineering-grade systems for AI and the web
         </h1>
         <p class="mt-5 text-lg text-zinc-700 max-w-prose">
           Measured software. Consistent by design. Built to scale without drift.

--- a/public/index.html
+++ b/public/index.html
@@ -71,7 +71,7 @@
       <div class="max-w-prose">
         <p class="pill">Made in Chicago</p>
         <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">
-          Engineering-grade systems for AI and the web.
+          Engineering-grade systems for AI and the web
         </h1>
         <p class="mt-5 text-lg text-zinc-700 max-w-prose">
           Measured software. Consistent by design. Built to scale without drift.


### PR DESCRIPTION
## Summary
- remove the trailing period from the homepage hero heading for cleaner copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e073ce83c08326ac2c6ae7db258ae3