### PR TITLE
Update homepage title for SEO clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Lakeshore — Engineering-grade systems for AI and the web</title>
+  <title>Lakeshore Design Agency — Engineering-grade systems for AI and the web</title>
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- update the homepage HTML title to use "Lakeshore Design Agency" for clearer branding in search results

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_e_68e0742895008326959436bbbfc1563c