### PR TITLE
Add favicon asset and references

### DIFF
--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-labelledby="title desc">
+  <title id="title">Lakeshore brand mark</title>
+  <desc id="desc">Deep blue circle with a white wave across the center.</desc>
+  <circle cx="50" cy="50" r="48" fill="#3552A3" />
+  <path d="M14 58 Q34 46 54 55 T94 55" fill="none" stroke="#FFFFFF" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
 
   <!-- Tailwind output -->
   <link rel="stylesheet" href="./assets/tailwind.css" />
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
   <meta name="theme-color" content="#3552A3">
 </head>
 <body class="font-sans">

--- a/public/assets/favicon.svg
+++ b/public/assets/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-labelledby="title desc">
+  <title id="title">Lakeshore brand mark</title>
+  <desc id="desc">Deep blue circle with a white wave across the center.</desc>
+  <circle cx="50" cy="50" r="48" fill="#3552A3" />
+  <path d="M14 58 Q34 46 54 55 T94 55" fill="none" stroke="#FFFFFF" stroke-width="12" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
 
   <!-- Tailwind output -->
   <link rel="stylesheet" href="./assets/tailwind.css" />
+  <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
   <meta name="theme-color" content="#3552A3">
 </head>
 <body class="font-sans">


### PR DESCRIPTION
## Summary
- add a reusable Lakeshore brandmark favicon SVG to the assets directories
- reference the favicon from both index documents so browsers load it

## Testing
- npm run build
- curl -I http://127.0.0.1:4173/assets/favicon.svg

------
https://chatgpt.com/codex/tasks/task_e_68e074a8413c8326a4715502f5aca085