### PR TITLE
Reduce navbar brandmark icon size

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         <a href="/" class="flex items-center gap-2">
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
           <!-- Brand mark (inherits color from the text color via currentColor) -->
-          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+          <svg class="h-4 w-4 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
             <!-- Filled circle uses currentColor so we can theme via Tailwind -->
             <circle cx="50" cy="50" r="48" fill="currentColor"/>
             <!-- Wave cutout (stays white for contrast) -->

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
         <a href="/" class="flex items-center gap-2">
           <span class="font-tight text-lg tracking-tight">Lakeshore</span>
           <!-- Brand mark (inherits color from the text color via currentColor) -->
-          <svg class="h-5 w-5 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
+          <svg class="h-4 w-4 text-deep-lake" viewBox="0 0 100 100" aria-hidden="true">
             <!-- Filled circle uses currentColor so we can theme via Tailwind -->
             <circle cx="50" cy="50" r="48" fill="currentColor"/>
             <!-- Wave cutout (stays white for contrast) -->


### PR DESCRIPTION
## Summary
- shrink the navbar brandmark SVG to 16px square while retaining its existing styling
- mirror the size adjustment in both the root and public builds so they stay in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e075f4433c83268dfe8715a1ca9f33