### PR TITLE
Add redirect shim for /local path

### DIFF
--- a/docs/local.html
+++ b/docs/local.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/local/" />
+    <title>Redirecting…</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/local/">/local/</a>…</p>
+  </body>
+</html>

--- a/public/local.html
+++ b/public/local.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=/local/" />
+    <title>Redirecting…</title>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/local/">/local/</a>…</p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a redirect shim at public/local.html that forwards visitors to /local/
- mirror the redirect file into docs/local.html so the published site behaves the same

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15d7501e4832691a0add8238fbb4a