### PR TITLE
Update Lakeshore Local beta messaging

### DIFF
--- a/local/index.html
+++ b/local/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Lakeshore Local — Vibe marketing for neighborhood businesses</title>
-  <meta name="description" content="Join the Lakeshore Local beta for vibe marketing builds that blend design, signage, and local funnels to bring nearby customers through the door." />
+  <title>Lakeshore Local Beta — Free websites + AI-powered marketing for local businesses</title>
+  <meta name="description" content="Lakeshore Local Beta offers free websites and AI-powered marketing support to help neighborhood businesses attract and keep local customers." />
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -35,7 +35,7 @@
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
-          <a class="btn btn-primary ml-2" href="mailto:hello@lakeshore.design?subject=Vibe%20Marketing%20Beta">Get free beta build</a>
+          <a class="btn btn-primary ml-2" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
         </nav>
         <button id="menuBtn" class="md:hidden btn btn-ghost px-3" aria-label="Open menu">Menu</button>
       </div>
@@ -44,7 +44,7 @@
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
         <a class="px-2 py-2 rounded hover:bg-mist" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
-        <a class="btn btn-primary mt-1 w-full" href="mailto:hello@lakeshore.design?subject=Vibe%20Marketing%20Beta">Get free beta build</a>
+        <a class="btn btn-primary mt-1 w-full" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
       </nav>
     </div>
   </header>
@@ -56,11 +56,11 @@
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
       <div class="mx-auto max-w-4xl px-4 pt-20 pb-24 md:pt-28 md:pb-28">
         <div class="max-w-2xl">
-          <p class="pill">Vibe Marketing Beta</p>
-          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Vibe marketing for local businesses.</h1>
-          <p class="mt-5 text-lg text-zinc-700">We co-build campaigns, signage, and microsites that feel like your neighborhood, then wire the analytics so you know who walks through the door. The beta is free while we prove the playbook with independent shops.</p>
+          <p class="pill">Lakeshore Local Beta</p>
+          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Free websites + AI-powered marketing for local businesses.</h1>
+          <p class="mt-5 text-lg text-zinc-700">Claim a no-cost site build paired with automations, signage, and analytics tuned to your neighborhood. We’re helping brick-and-mortar teams launch modern funnels without agency retainers.</p>
           <div class="mt-8 flex flex-wrap items-center gap-3">
-            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Vibe%20Marketing%20Beta">Get free beta build</a>
+            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
             <a class="btn btn-ghost" href="#what-this-is">See how it works</a>
           </div>
         </div>
@@ -188,7 +188,7 @@
               <h2 class="font-tight text-2xl tracking-tight">Ready to run a vibe marketing drop?</h2>
               <p class="text-sm text-zinc-700">Tell us about your shop, opening hours, and goal. We'll reply with the beta intake checklist.</p>
             </div>
-            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Vibe%20Marketing%20Beta">Get free beta build</a>
+            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- update the local landing page head tags to reflect the Lakeshore Local Beta messaging
- refresh the hero copy and CTA to highlight free websites with AI-powered marketing
- align repeated CTA buttons with the new "Get Your Free Build" mailto link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1711e55608326ac2fb8cad46ab298