### PR TITLE
Replace selected work gradients with project imagery

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -217,24 +217,9 @@
     <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Selected work</h2>
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-deep-lake/10 via-white to-sky-100/40 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex gap-2">
-              <span class="h-2 flex-1 rounded-full bg-deep-lake/70"></span>
-              <span class="h-2 w-10 rounded-full bg-deep-lake/30"></span>
-              <span class="h-2 w-6 rounded-full bg-deep-lake/20"></span>
-            </div>
-            <div class="grid flex-1 grid-cols-4 gap-2 pt-4">
-              <span class="col-span-2 rounded-lg border border-deep-lake/20 bg-white/80"></span>
-              <span class="rounded-lg border border-deep-lake/20 bg-deep-lake/10"></span>
-              <span class="rounded-lg border border-deep-lake/20 bg-deep-lake/5"></span>
-              <span class="col-span-4 h-2 rounded bg-deep-lake/40"></span>
-              <span class="col-span-3 h-2 rounded bg-deep-lake/20"></span>
-              <span class="h-2 rounded bg-deep-lake/20"></span>
-              <span class="col-span-2 h-2 rounded bg-deep-lake/10"></span>
-              <span class="col-span-2 h-2 rounded bg-deep-lake/10"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/inkeep.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Catalog Intelligence UI project for Inkeep showing analytics dashboards" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Catalog Intelligence UI</h3>
@@ -243,23 +228,9 @@
         </div>
       </article>
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-amber-100/60 via-white to-orange-100/40 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex gap-3">
-              <span class="h-3 w-16 rounded-full bg-amber-400/80"></span>
-              <span class="h-3 w-10 rounded-full bg-amber-400/50"></span>
-              <span class="h-3 w-8 rounded-full bg-amber-400/30"></span>
-            </div>
-            <div class="grid flex-1 grid-cols-6 gap-2 pt-4">
-              <span class="col-span-3 rounded-lg border border-amber-300/70 bg-white/80"></span>
-              <span class="col-span-3 rounded-lg border border-amber-300/70 bg-amber-200/40"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/60"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/40"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/30"></span>
-              <span class="col-span-3 h-2 rounded bg-amber-400/40"></span>
-              <span class="col-span-3 h-2 rounded bg-amber-400/20"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/plain.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Headless commerce storefront redesign for Plain with modular product cards" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Headless Commerce Revamp</h3>
@@ -268,25 +239,9 @@
         </div>
       </article>
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-emerald-100/50 via-white to-emerald-50 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex items-center gap-3">
-              <span class="h-10 w-10 rounded-lg border border-emerald-300 bg-white/80"></span>
-              <div class="flex-1 space-y-2">
-                <span class="block h-3 w-3/4 rounded bg-emerald-400/70"></span>
-                <span class="block h-3 w-1/2 rounded bg-emerald-400/40"></span>
-              </div>
-            </div>
-            <div class="grid flex-1 grid-cols-4 gap-2 pt-4">
-              <span class="col-span-2 h-2 rounded bg-emerald-400/60"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-4 rounded-lg border border-emerald-300/70 bg-white/80"></span>
-              <span class="col-span-1 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-3 h-2 rounded bg-emerald-400/20"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/10"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/ekom.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Ekom operations automation suite dashboard streamlining fulfillment workflows" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Ops Automation Suite</h3>

--- a/index.html
+++ b/index.html
@@ -217,24 +217,9 @@
     <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Selected work</h2>
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-deep-lake/10 via-white to-sky-100/40 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex gap-2">
-              <span class="h-2 flex-1 rounded-full bg-deep-lake/70"></span>
-              <span class="h-2 w-10 rounded-full bg-deep-lake/30"></span>
-              <span class="h-2 w-6 rounded-full bg-deep-lake/20"></span>
-            </div>
-            <div class="grid flex-1 grid-cols-4 gap-2 pt-4">
-              <span class="col-span-2 rounded-lg border border-deep-lake/20 bg-white/80"></span>
-              <span class="rounded-lg border border-deep-lake/20 bg-deep-lake/10"></span>
-              <span class="rounded-lg border border-deep-lake/20 bg-deep-lake/5"></span>
-              <span class="col-span-4 h-2 rounded bg-deep-lake/40"></span>
-              <span class="col-span-3 h-2 rounded bg-deep-lake/20"></span>
-              <span class="h-2 rounded bg-deep-lake/20"></span>
-              <span class="col-span-2 h-2 rounded bg-deep-lake/10"></span>
-              <span class="col-span-2 h-2 rounded bg-deep-lake/10"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/inkeep.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Catalog Intelligence UI project for Inkeep showing analytics dashboards" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Catalog Intelligence UI</h3>
@@ -243,23 +228,9 @@
         </div>
       </article>
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-amber-100/60 via-white to-orange-100/40 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex gap-3">
-              <span class="h-3 w-16 rounded-full bg-amber-400/80"></span>
-              <span class="h-3 w-10 rounded-full bg-amber-400/50"></span>
-              <span class="h-3 w-8 rounded-full bg-amber-400/30"></span>
-            </div>
-            <div class="grid flex-1 grid-cols-6 gap-2 pt-4">
-              <span class="col-span-3 rounded-lg border border-amber-300/70 bg-white/80"></span>
-              <span class="col-span-3 rounded-lg border border-amber-300/70 bg-amber-200/40"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/60"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/40"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/30"></span>
-              <span class="col-span-3 h-2 rounded bg-amber-400/40"></span>
-              <span class="col-span-3 h-2 rounded bg-amber-400/20"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/plain.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Headless commerce storefront redesign for Plain with modular product cards" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Headless Commerce Revamp</h3>
@@ -268,25 +239,9 @@
         </div>
       </article>
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-emerald-100/50 via-white to-emerald-50 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex items-center gap-3">
-              <span class="h-10 w-10 rounded-lg border border-emerald-300 bg-white/80"></span>
-              <div class="flex-1 space-y-2">
-                <span class="block h-3 w-3/4 rounded bg-emerald-400/70"></span>
-                <span class="block h-3 w-1/2 rounded bg-emerald-400/40"></span>
-              </div>
-            </div>
-            <div class="grid flex-1 grid-cols-4 gap-2 pt-4">
-              <span class="col-span-2 h-2 rounded bg-emerald-400/60"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-4 rounded-lg border border-emerald-300/70 bg-white/80"></span>
-              <span class="col-span-1 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-3 h-2 rounded bg-emerald-400/20"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/10"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/ekom.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Ekom operations automation suite dashboard streamlining fulfillment workflows" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Ops Automation Suite</h3>

--- a/public/index.html
+++ b/public/index.html
@@ -217,24 +217,9 @@
     <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Selected work</h2>
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-deep-lake/10 via-white to-sky-100/40 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex gap-2">
-              <span class="h-2 flex-1 rounded-full bg-deep-lake/70"></span>
-              <span class="h-2 w-10 rounded-full bg-deep-lake/30"></span>
-              <span class="h-2 w-6 rounded-full bg-deep-lake/20"></span>
-            </div>
-            <div class="grid flex-1 grid-cols-4 gap-2 pt-4">
-              <span class="col-span-2 rounded-lg border border-deep-lake/20 bg-white/80"></span>
-              <span class="rounded-lg border border-deep-lake/20 bg-deep-lake/10"></span>
-              <span class="rounded-lg border border-deep-lake/20 bg-deep-lake/5"></span>
-              <span class="col-span-4 h-2 rounded bg-deep-lake/40"></span>
-              <span class="col-span-3 h-2 rounded bg-deep-lake/20"></span>
-              <span class="h-2 rounded bg-deep-lake/20"></span>
-              <span class="col-span-2 h-2 rounded bg-deep-lake/10"></span>
-              <span class="col-span-2 h-2 rounded bg-deep-lake/10"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/inkeep.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Catalog Intelligence UI project for Inkeep showing analytics dashboards" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Catalog Intelligence UI</h3>
@@ -243,23 +228,9 @@
         </div>
       </article>
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-amber-100/60 via-white to-orange-100/40 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex gap-3">
-              <span class="h-3 w-16 rounded-full bg-amber-400/80"></span>
-              <span class="h-3 w-10 rounded-full bg-amber-400/50"></span>
-              <span class="h-3 w-8 rounded-full bg-amber-400/30"></span>
-            </div>
-            <div class="grid flex-1 grid-cols-6 gap-2 pt-4">
-              <span class="col-span-3 rounded-lg border border-amber-300/70 bg-white/80"></span>
-              <span class="col-span-3 rounded-lg border border-amber-300/70 bg-amber-200/40"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/60"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/40"></span>
-              <span class="col-span-2 h-2 rounded bg-amber-400/30"></span>
-              <span class="col-span-3 h-2 rounded bg-amber-400/40"></span>
-              <span class="col-span-3 h-2 rounded bg-amber-400/20"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/plain.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Headless commerce storefront redesign for Plain with modular product cards" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Headless Commerce Revamp</h3>
@@ -268,25 +239,9 @@
         </div>
       </article>
       <article class="card overflow-hidden">
-        <div class="aspect-[3/2] bg-gradient-to-br from-emerald-100/50 via-white to-emerald-50 p-5">
-          <div class="flex h-full flex-col justify-between" aria-hidden="true">
-            <div class="flex items-center gap-3">
-              <span class="h-10 w-10 rounded-lg border border-emerald-300 bg-white/80"></span>
-              <div class="flex-1 space-y-2">
-                <span class="block h-3 w-3/4 rounded bg-emerald-400/70"></span>
-                <span class="block h-3 w-1/2 rounded bg-emerald-400/40"></span>
-              </div>
-            </div>
-            <div class="grid flex-1 grid-cols-4 gap-2 pt-4">
-              <span class="col-span-2 h-2 rounded bg-emerald-400/60"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-4 rounded-lg border border-emerald-300/70 bg-white/80"></span>
-              <span class="col-span-1 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-3 h-2 rounded bg-emerald-400/20"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/30"></span>
-              <span class="col-span-2 h-2 rounded bg-emerald-400/10"></span>
-            </div>
-          </div>
+        <div class="aspect-[3/2]">
+          <img src="/assets/images/ekom.webp" class="h-full w-full object-cover" loading="lazy"
+            alt="Ekom operations automation suite dashboard streamlining fulfillment workflows" />
         </div>
         <div class="p-6 space-y-3">
           <h3 class="font-medium">Ops Automation Suite</h3>


### PR DESCRIPTION
## Summary
- replace the selected work gradient placeholders with project images and descriptive alt text
- update the built public and docs outputs to mirror the homepage changes

## Testing
- python -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1773a20388326892c8e7c6d4c21d0