### PR TITLE
Update Lakeshore Local beta messaging

### DIFF
--- a/local/index.html
+++ b/local/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Lakeshore Local Beta — Free websites + AI-powered marketing for local businesses</title>
-  <meta name="description" content="Lakeshore Local Beta offers free websites and AI-powered marketing support to help neighborhood businesses attract and keep local customers." />
+  <meta name="description" content="Join the Lakeshore Local Beta for a free website build and AI-powered local marketing that launches in days, not months." />
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -55,23 +55,15 @@
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
       <div class="mx-auto max-w-4xl px-4 pt-20 pb-24 md:pt-28 md:pb-28">
-        <div class="max-w-2xl">
-          <p class="pill">Lakeshore Local Beta</p>
-          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Free websites + AI-powered marketing for local businesses.</h1>
-          <p class="mt-5 text-lg text-zinc-700">Claim a no-cost site build paired with automations, signage, and analytics tuned to your neighborhood. We’re helping brick-and-mortar teams launch modern funnels without agency retainers.</p>
-          <div class="mt-8 flex flex-wrap items-center gap-3">
+        <div class="max-w-2xl space-y-6">
+          <p class="pill">Beta Program</p>
+          <h1 class="font-tight text-4xl md:text-5xl tracking-tight">Lakeshore Local Beta</h1>
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight text-deep-lake">Free websites + AI-powered marketing for local businesses</h2>
+          <p class="text-lg text-zinc-700">We’re testing a new playbook: using AI to build and rank local service websites in days, not months. Our beta partners get everything free while we prove it works.</p>
+          <div class="flex flex-wrap items-center gap-3">
             <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
-            <a class="btn btn-ghost" href="#what-this-is">See how it works</a>
+            <a class="btn btn-ghost" href="#how-it-works">See how it works</a>
           </div>
-        </div>
-        <div class="mt-12">
-          <h2 class="text-sm font-semibold uppercase tracking-wide text-zinc-500">Quick-hit CTAs</h2>
-          <ul class="mt-4 flex flex-wrap gap-2 text-sm text-zinc-700">
-            <li><span class="pill">Plan a vibe drop</span></li>
-            <li><span class="pill">Refresh your windows</span></li>
-            <li><span class="pill">Tune a promo funnel</span></li>
-            <li><span class="pill">Measure walk-ins</span></li>
-          </ul>
         </div>
       </div>
     </section>
@@ -80,109 +72,63 @@
       <div class="space-y-16">
         <section id="why-this-matters" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Why this matters</h2>
-          <p class="text-zinc-700">Local shops win when the story outside the door matches the experience inside. Lakeshore Local is a <strong>hands-on beta</strong> built to give neighborhood teams agency-grade creative without agency lag. We combine brand, copy, and lightweight tech so you can launch the next drop while the idea is still warm.</p>
           <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li><strong>Speed beats legacy.</strong> We swap agency decks for weekly drops—posters, reels, and emails go live while the idea is still hot.</li>
-            <li><strong>Local data &gt; national averages.</strong> We track foot traffic, QR scans, and POS bumps so each campaign gets tuned to your block.</li>
-            <li><strong>Neighborhood-first creative.</strong> Every asset is built with your regulars in mind: real photos, language they use, and moments they care about.</li>
-          </ul>
-        </section>
-
-        <section id="who-this-is-for" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Who this is for</h2>
-          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Cafés and bakeries introducing seasonal menus or merch drops.</li>
-            <li>Fitness, wellness, and studio teams filling new class formats.</li>
-            <li>Retailers refreshing window displays and local promos.</li>
-            <li>Service pros—salons, bike repair, florists—testing membership offers.</li>
+            <li>Speed beats legacy: AI can launch and rank a site in as little as 48 hours.</li>
+            <li>No website? Perfect. We specialize in businesses with no online presence.</li>
+            <li>More leads, less hassle: Your phone starts ringing—we handle the site + SEO.</li>
           </ul>
         </section>
 
         <section id="what-you-get" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What you get <span class="text-sm font-medium text-deep-lake">(beta = free)</span></h2>
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What you get <span class="text-sm font-medium text-deep-lake">(free during beta)</span></h2>
           <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Brand and copy refresh tuned to your neighborhood vibe.</li>
-            <li>Window, in-store, and street signage designed for quick print runs.</li>
-            <li>Microsite or landing page with QR-ready funnel and analytics.</li>
-            <li>Weekly co-working sessions to adjust creative and offers in real time.</li>
+            <li>A clean, fast website tuned for your services + neighborhoods.</li>
+            <li>AI-optimized pages for each service and location.</li>
+            <li>Google Business Profile setup and local SEO basics.</li>
+            <li>Call + form tracking so you see real leads coming in.</li>
           </ul>
         </section>
 
         <section id="what-we-need" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What we need from you</h2>
           <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>A founder or GM who can green-light copy, offers, and installs quickly.</li>
-            <li>Access to your brand assets, POS data, and any list you want to activate.</li>
-            <li>Agreement to share performance metrics so we can publish before/after results.</li>
-            <li>Feedback on what feels on-brand, what misses, and what you need next.</li>
+            <li>Your services, service areas, and phone number.</li>
+            <li>A few photos or short videos (taken on your phone is fine).</li>
+            <li>Permission to publish results as a case study.</li>
+          </ul>
+        </section>
+
+        <section id="who-this-is-for" class="space-y-4">
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Who this is for</h2>
+          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
+            <li>Service businesses without a site (snow removal, lawn care, repair shops, salons).</li>
+            <li>Owners who want more calls and walk-ins—fast.</li>
+            <li>People open to trying AI-powered marketing while it’s free.</li>
           </ul>
         </section>
 
         <section id="how-it-works" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">How the build works</h2>
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">How it works</h2>
           <ol class="list-decimal space-y-3 pl-5 text-zinc-700">
-            <li><strong>Neighborhood audit:</strong> We walk the block, review your touchpoints, and define the vibe to amplify.</li>
-            <li><strong>Beta build:</strong> We design creative, spin up the microsite, and prep print-ready files.</li>
-            <li><strong>Live activation:</strong> Install signage, launch promos, and hook up analytics for the run.</li>
-            <li><strong>Review &amp; reset:</strong> We debrief with metrics, capture lessons, and plan the next drop.</li>
+            <li><strong>Intake:</strong> You give us services + areas served.</li>
+            <li><strong>Build:</strong> We launch your site with AI + SEO built in.</li>
+            <li><strong>Rank:</strong> Pages optimized → submitted to Google → start showing up fast.</li>
+            <li><strong>Calls:</strong> Leads route straight to your phone.</li>
           </ol>
-        </section>
-
-        <section id="timeline" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Timeline</h2>
-          <div class="grid gap-4 md:grid-cols-3">
-            <div class="card p-5">
-              <div class="pill mb-2">Week 0</div>
-              <h3 class="font-medium">Kickoff</h3>
-              <p class="mt-1 text-sm text-zinc-700">Audit the shop, gather assets, set the first beta goal.</p>
-            </div>
-            <div class="card p-5">
-              <div class="pill mb-2">Weeks 1–4</div>
-              <h3 class="font-medium">Create & launch</h3>
-              <p class="mt-1 text-sm text-zinc-700">Design assets, publish the microsite, and run the activation.</p>
-            </div>
-            <div class="card p-5">
-              <div class="pill mb-2">Weeks 5–6</div>
-              <h3 class="font-medium">Measure & repeat</h3>
-              <p class="mt-1 text-sm text-zinc-700">Review results, capture footage, and plan the next neighborhood drop.</p>
-            </div>
-          </div>
         </section>
 
         <section id="pricing" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Beta pricing</h2>
-          <p class="text-zinc-700">During beta, Lakeshore Local vibe marketing builds are <strong>free</strong> in exchange for shared metrics and a public mini case study. When we exit beta, pricing will shift to a flat monthly creative fee plus production costs—beta partners lock in founding rates and a guaranteed launch window each quarter.</p>
-        </section>
-
-        <section id="proof" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Proof & transparency</h2>
-          <p class="text-zinc-700">We show the work. Expect <strong>shared dashboards</strong> for walk-ins, QR scans, list growth, and campaign ROI. Weekly recaps highlight what resonated and what we’re changing next.</p>
-          <p class="text-zinc-700">You’ll also see anonymized learnings from other beta shops—signage prints, landing page heatmaps, and offer tests that moved the needle.</p>
-        </section>
-
-        <section id="faq" class="space-y-6">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">FAQ</h2>
-          <div class="space-y-4">
-            <div class="card p-5 space-y-2">
-              <h3 class="font-medium">Do we need a big marketing team?</h3>
-              <p class="text-sm text-zinc-700">Nope. Most beta partners are owner-operators or lean teams. We bring the design, copy, and lightweight tech—just loop in whoever approves offers and signage.</p>
-            </div>
-            <div class="card p-5 space-y-2">
-              <h3 class="font-medium">Who covers printing and media spend?</h3>
-              <p class="text-sm text-zinc-700">During beta we’ll design everything and share ready-to-print files. You cover hard costs like printing, boosts, or ad buys so we can move fast without procurement delays.</p>
-            </div>
-            <div class="card p-5 space-y-2">
-              <h3 class="font-medium">How long does the beta run?</h3>
-              <p class="text-sm text-zinc-700">Each build runs about six weeks from kickoff to recap. After beta you can roll into the paid program with founding rates or take the assets and run your own campaigns.</p>
-            </div>
-          </div>
+          <p class="text-zinc-700">$0. Free build + free optimization while in beta.</p>
+          <p class="text-zinc-700">You keep the leads.</p>
+          <p class="text-zinc-700">Later: optional pay-per-lead or flat monthly.</p>
         </section>
 
         <section id="join" class="space-y-4">
           <div class="card p-6 md:p-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 class="font-tight text-2xl tracking-tight">Ready to be a beta partner?</h2>
-              <p class="text-sm text-zinc-700">Tell us about your shop, opening hours, and goal. We'll reply with the beta intake checklist.</p>
+            <div class="space-y-2">
+              <h2 class="font-tight text-2xl tracking-tight">👉 Ready to be a beta partner?</h2>
+              <p class="text-sm text-zinc-700">Get Your Free Build</p>
             </div>
             <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
           </div>

--- a/public/local/index.html
+++ b/public/local/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Lakeshore Local — Private beta for on-prem builds</title>
-  <meta name="description" content="Join the Lakeshore Local beta to run our measured build systems on your own hardware with direct engineering support." />
+  <title>Lakeshore Local Beta — Free websites + AI-powered marketing for local businesses</title>
+  <meta name="description" content="Join the Lakeshore Local Beta for a free website build and AI-powered local marketing that launches in days, not months." />
 
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -35,7 +35,7 @@
         <nav class="hidden md:flex items-center gap-6 text-sm">
           <a class="hover:text-deep-lake" href="/blog/">Blog</a>
           <a class="hover:text-deep-lake" href="/#contact">Contact</a>
-          <a class="btn btn-primary ml-2" href="/#contact">Start a project</a>
+          <a class="btn btn-primary ml-2" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
         </nav>
         <button id="menuBtn" class="md:hidden btn btn-ghost px-3" aria-label="Open menu">Menu</button>
       </div>
@@ -44,7 +44,7 @@
       <nav class="mx-auto max-w-6xl px-4 py-2 grid gap-1 text-sm">
         <a class="px-2 py-2 rounded hover:bg-mist" href="/blog/">Blog</a>
         <a class="px-2 py-2 rounded hover:bg-mist" href="/#contact">Contact</a>
-        <a class="btn btn-primary mt-1 w-full" href="/#contact">Start a project</a>
+        <a class="btn btn-primary mt-1 w-full" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
       </nav>
     </div>
   </header>
@@ -55,140 +55,82 @@
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(60%_40%_at_50%_0%,rgba(53,82,163,0.18)_0%,rgba(53,82,163,0)_60%)]"></div>
       <div class="pointer-events-none absolute inset-0 -z-10 bg-[linear-gradient(120deg,rgba(255,255,255,0.0)_0%,rgba(255,255,255,0.4)_8%,rgba(255,255,255,0.0)_16%)] opacity-20"></div>
       <div class="mx-auto max-w-4xl px-4 pt-20 pb-24 md:pt-28 md:pb-28">
-        <div class="max-w-2xl">
-          <p class="pill">Introducing Lakeshore Local</p>
-          <h1 class="mt-6 font-tight text-4xl md:text-5xl tracking-tight">Run our measured systems on hardware you control.</h1>
-          <p class="mt-5 text-lg text-zinc-700">The Lakeshore Local beta pairs hardened build tooling, observability, and human-in-the-loop QA so teams can ship sensitive AI and web features without leaving their network.</p>
-          <div class="mt-8 flex flex-wrap items-center gap-3">
-            <a class="btn btn-primary" href="#join">Request beta access</a>
-            <a class="btn btn-ghost" href="/#contact">Talk with the team</a>
+        <div class="max-w-2xl space-y-6">
+          <p class="pill">Beta Program</p>
+          <h1 class="font-tight text-4xl md:text-5xl tracking-tight">Lakeshore Local Beta</h1>
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight text-deep-lake">Free websites + AI-powered marketing for local businesses</h2>
+          <p class="text-lg text-zinc-700">We’re testing a new playbook: using AI to build and rank local service websites in days, not months. Our beta partners get everything free while we prove it works.</p>
+          <div class="flex flex-wrap items-center gap-3">
+            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
+            <a class="btn btn-ghost" href="#how-it-works">See how it works</a>
           </div>
-        </div>
-        <div class="mt-12">
-          <h2 class="text-sm font-semibold uppercase tracking-wide text-zinc-500">Reusable micro-copy CTAs</h2>
-          <ul class="mt-4 flex flex-wrap gap-2 text-sm text-zinc-700">
-            <li><span class="pill">Ship a Local build</span></li>
-            <li><span class="pill">Schedule a pairing session</span></li>
-            <li><span class="pill">Share your instrumentation</span></li>
-            <li><span class="pill">Invite a security review</span></li>
-          </ul>
         </div>
       </div>
     </section>
 
     <section class="mx-auto max-w-4xl px-4 pb-24">
       <div class="space-y-16">
-        <section id="what-this-is" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What this is</h2>
-          <p class="text-zinc-700">Lakeshore Local is a <strong>hands-on beta</strong> for teams who need Lakeshore-grade delivery but must keep code, data, and artifacts on-premises. We bring our tooling and playbooks into your environment, wire it up with your CI, and stand up a clear surface area for everyone involved.</p>
-        </section>
-
-        <section id="why-it-works" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Why it works now</h2>
+        <section id="why-this-matters" class="space-y-4">
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Why this matters</h2>
           <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li><strong>Containerized pipelines</strong> keep builds reproducible across developer laptops, secure sandboxes, and your production edge.</li>
-            <li><strong>Eval harnesses</strong> run inside your perimeter so AI features stay measurable without exposing prompts or data.</li>
-            <li><strong>Instrumented playbooks</strong> are tuned from real client work: fewer regressions, faster approvals, same reliability we ship on hosted projects.</li>
+            <li>Speed beats legacy: AI can launch and rank a site in as little as 48 hours.</li>
+            <li>No website? Perfect. We specialize in businesses with no online presence.</li>
+            <li>More leads, less hassle: Your phone starts ringing—we handle the site + SEO.</li>
           </ul>
         </section>
 
         <section id="what-you-get" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What you get <span class="text-sm font-medium text-deep-lake">(Beta = free)</span></h2>
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What you get <span class="text-sm font-medium text-deep-lake">(free during beta)</span></h2>
           <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Co-designed build plan covering AI services, web releases, and observability.</li>
-            <li>Local-first CICD templates, infra IaC snippets, and instrumentation dashboards.</li>
-            <li>Weekly pairing windows with Lakeshore engineers during the beta period.</li>
-            <li>Priority invite to production-grade release once Local hits general availability.</li>
+            <li>A clean, fast website tuned for your services + neighborhoods.</li>
+            <li>AI-optimized pages for each service and location.</li>
+            <li>Google Business Profile setup and local SEO basics.</li>
+            <li>Call + form tracking so you see real leads coming in.</li>
           </ul>
         </section>
 
         <section id="what-we-need" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What we need from you</h2>
           <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>A project owner empowered to approve environment changes quickly.</li>
-            <li>Sandbox or staging infrastructure where we can prove the full loop.</li>
-            <li>Agreement to share anonymized performance metrics so we can iterate the beta.</li>
-            <li>Honest feedback—where the tooling feels slow, unclear, or brittle.</li>
+            <li>Your services, service areas, and phone number.</li>
+            <li>A few photos or short videos (taken on your phone is fine).</li>
+            <li>Permission to publish results as a case study.</li>
+          </ul>
+        </section>
+
+        <section id="who-this-is-for" class="space-y-4">
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Who this is for</h2>
+          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
+            <li>Service businesses without a site (snow removal, lawn care, repair shops, salons).</li>
+            <li>Owners who want more calls and walk-ins—fast.</li>
+            <li>People open to trying AI-powered marketing while it’s free.</li>
           </ul>
         </section>
 
         <section id="how-it-works" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">How the build works</h2>
+          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">How it works</h2>
           <ol class="list-decimal space-y-3 pl-5 text-zinc-700">
-            <li><strong>Kickoff mapping:</strong> We audit your repo, infrastructure, and compliance guardrails to define scope.</li>
-            <li><strong>Local orchestration:</strong> We provision the build runners and pipelines alongside your current tooling.</li>
-            <li><strong>Proof run:</strong> Together we ship a meaningful feature to validate the instrumentation and QA.</li>
-            <li><strong>Team enablement:</strong> We document the runbooks and train your team so they can operate without us.</li>
+            <li><strong>Intake:</strong> You give us services + areas served.</li>
+            <li><strong>Build:</strong> We launch your site with AI + SEO built in.</li>
+            <li><strong>Rank:</strong> Pages optimized → submitted to Google → start showing up fast.</li>
+            <li><strong>Calls:</strong> Leads route straight to your phone.</li>
           </ol>
-        </section>
-
-        <section id="timeline" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Timeline</h2>
-          <div class="grid gap-4 md:grid-cols-3">
-            <div class="card p-5">
-              <div class="pill mb-2">Week 0</div>
-              <h3 class="font-medium">Scoping</h3>
-              <p class="mt-1 text-sm text-zinc-700">Map requirements, confirm access, align on win conditions.</p>
-            </div>
-            <div class="card p-5">
-              <div class="pill mb-2">Weeks 1–4</div>
-              <h3 class="font-medium">Build & prove</h3>
-              <p class="mt-1 text-sm text-zinc-700">Stand up pipelines, ship the first Local release, evaluate.</p>
-            </div>
-            <div class="card p-5">
-              <div class="pill mb-2">Weeks 5–6</div>
-              <h3 class="font-medium">Enable & iterate</h3>
-              <p class="mt-1 text-sm text-zinc-700">Close gaps, extend automations, hand off docs and dashboards.</p>
-            </div>
-          </div>
         </section>
 
         <section id="pricing" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Beta pricing</h2>
-          <p class="text-zinc-700">During beta, Lakeshore Local is <strong>free</strong> in exchange for structured feedback and a short shared case study. When we exit beta, pricing will reflect the hosted program: a flat monthly platform fee plus an engagement-based retainer for custom engineering. Beta teams lock in founding rates and direct influence on the roadmap.</p>
-        </section>
-
-        <section id="use-cases" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Use cases we like</h2>
-          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Regulated teams building AI copilots that must stay inside a private VPC.</li>
-            <li>E-commerce operators with strict merchandising SLAs who need deterministic deploys.</li>
-            <li>Marketing or editorial teams with heavy compliance review that want measurable speed gains.</li>
-            <li>Ops groups automating support workflows while keeping PII locked down.</li>
-          </ul>
-        </section>
-
-        <section id="proof" class="space-y-4">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Proof & transparency</h2>
-          <p class="text-zinc-700">Local is built on the same rails as our client delivery practice. Expect <strong>shared dashboards</strong> showing deployment frequency, failure rate, and time-to-restore. We run weekly post-launch reviews and publish changelogs so your stakeholders see exactly what shipped and why.</p>
-          <p class="text-zinc-700">We also surface anonymized learnings from other beta partners—what worked, what stalled, and the measurable deltas that unlocked their approvals.</p>
-        </section>
-
-        <section id="faq" class="space-y-6">
-          <h2 class="font-tight text-2xl md:text-3xl tracking-tight">FAQ</h2>
-          <div class="space-y-4">
-            <div class="card p-5 space-y-2">
-              <h3 class="font-medium">Do we need to rip out our existing CI?</h3>
-              <p class="text-sm text-zinc-700">No. We layer on top of your current CI/CD and only replace pieces that are blocking measurable progress. Most teams keep their existing runners and use our templates as reusable jobs.</p>
-            </div>
-            <div class="card p-5 space-y-2">
-              <h3 class="font-medium">Will you handle security reviews?</h3>
-              <p class="text-sm text-zinc-700">We prepare the documentation and pair with your security team. If you need third-party attestation, we coordinate with your vendor so requirements stay on track.</p>
-            </div>
-            <div class="card p-5 space-y-2">
-              <h3 class="font-medium">How long does access last?</h3>
-              <p class="text-sm text-zinc-700">Beta access runs through the enablement phase and includes a 60-day follow-up window. After that, teams can transition into a light retainer or wait for GA licensing.</p>
-            </div>
-          </div>
+          <p class="text-zinc-700">$0. Free build + free optimization while in beta.</p>
+          <p class="text-zinc-700">You keep the leads.</p>
+          <p class="text-zinc-700">Later: optional pay-per-lead or flat monthly.</p>
         </section>
 
         <section id="join" class="space-y-4">
           <div class="card p-6 md:p-8 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 class="font-tight text-2xl tracking-tight">Ready to try Lakeshore Local?</h2>
-              <p class="text-sm text-zinc-700">Tell us about the system you need to ship. We'll send the beta intake checklist.</p>
+            <div class="space-y-2">
+              <h2 class="font-tight text-2xl tracking-tight">👉 Ready to be a beta partner?</h2>
+              <p class="text-sm text-zinc-700">Get Your Free Build</p>
             </div>
-            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20beta">Email the team</a>
+            <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>
           </div>
         </section>
       </div>


### PR DESCRIPTION
## Summary
- replace the Lakeshore Local hero and supporting sections with the new beta program copy
- mirror the refreshed messaging in the published static page and CTA module
- update the meta description to highlight the fast AI-powered site launch focus

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1797213648326b423b927633eaa7c