### PR TITLE
Refine local beta sections with card layouts

### DIFF
--- a/local/index.html
+++ b/local/index.html
@@ -72,49 +72,151 @@
       <div class="space-y-16">
         <section id="why-this-matters" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Why this matters</h2>
-          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Speed beats legacy: AI can launch and rank a site in as little as 48 hours.</li>
-            <li>No website? Perfect. We specialize in businesses with no online presence.</li>
-            <li>More leads, less hassle: Your phone starts ringing—we handle the site + SEO.</li>
-          </ul>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">⚡</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Speed beats legacy</h3>
+                <p class="text-sm text-zinc-700">AI can launch and rank a site in as little as 48 hours.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">🌐</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">From blank to online</h3>
+                <p class="text-sm text-zinc-700">No website? Perfect. We specialize in businesses with no online presence.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4 md:col-span-2 md:flex-row">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">📞</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">More leads, less hassle</h3>
+                <p class="text-sm text-zinc-700">Your phone starts ringing—we handle the site, SEO, and upkeep.</p>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section id="what-you-get" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What you get <span class="text-sm font-medium text-deep-lake">(free during beta)</span></h2>
-          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>A clean, fast website tuned for your services + neighborhoods.</li>
-            <li>AI-optimized pages for each service and location.</li>
-            <li>Google Business Profile setup and local SEO basics.</li>
-            <li>Call + form tracking so you see real leads coming in.</li>
-          </ul>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">🧭</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">High-velocity site</h3>
+                <p class="text-sm text-zinc-700">A clean, fast website tuned for your services and neighborhoods.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">🤖</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">AI-optimized pages</h3>
+                <p class="text-sm text-zinc-700">Every service and location gets copy tuned for search right away.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">📍</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Google basics handled</h3>
+                <p class="text-sm text-zinc-700">Google Business Profile setup and foundational local SEO.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">📈</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Lead tracking built in</h3>
+                <p class="text-sm text-zinc-700">Call and form tracking so you can see real leads coming in.</p>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section id="what-we-need" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">What we need from you</h2>
-          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Your services, service areas, and phone number.</li>
-            <li>A few photos or short videos (taken on your phone is fine).</li>
-            <li>Permission to publish results as a case study.</li>
-          </ul>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">🗒️</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Basic business info</h3>
+                <p class="text-sm text-zinc-700">Share your services, service areas, and the best phone number.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">📸</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Visuals from your phone</h3>
+                <p class="text-sm text-zinc-700">A few photos or short videos—shot on your phone is perfect.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4 md:col-span-2">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">✅</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Case study permission</h3>
+                <p class="text-sm text-zinc-700">Allow us to publish performance results as a case study.</p>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section id="who-this-is-for" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">Who this is for</h2>
-          <ul class="list-disc space-y-2 pl-5 text-zinc-700">
-            <li>Service businesses without a site (snow removal, lawn care, repair shops, salons).</li>
-            <li>Owners who want more calls and walk-ins—fast.</li>
-            <li>People open to trying AI-powered marketing while it’s free.</li>
-          </ul>
+          <div class="grid gap-6 md:grid-cols-2">
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">🛠️</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Local service pros</h3>
+                <p class="text-sm text-zinc-700">Snow removal, lawn care, repair shops, salons, and similar teams.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">📞</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Owners who want calls</h3>
+                <p class="text-sm text-zinc-700">People who want more calls and walk-ins—fast.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4 md:col-span-2">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-mist text-lg text-deep-lake" aria-hidden="true">🚀</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Curious early adopters</h3>
+                <p class="text-sm text-zinc-700">Folks open to trying AI-powered marketing while it’s free.</p>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section id="how-it-works" class="space-y-4">
           <h2 class="font-tight text-2xl md:text-3xl tracking-tight">How it works</h2>
-          <ol class="list-decimal space-y-3 pl-5 text-zinc-700">
-            <li><strong>Intake:</strong> You give us services + areas served.</li>
-            <li><strong>Build:</strong> We launch your site with AI + SEO built in.</li>
-            <li><strong>Rank:</strong> Pages optimized → submitted to Google → start showing up fast.</li>
-            <li><strong>Calls:</strong> Leads route straight to your phone.</li>
-          </ol>
+          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-deep-lake text-sm font-semibold text-white" aria-hidden="true">1</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Intake</h3>
+                <p class="text-sm text-zinc-700">Share your services and the areas you want to cover.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-deep-lake text-sm font-semibold text-white" aria-hidden="true">2</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Build</h3>
+                <p class="text-sm text-zinc-700">We launch your site with AI-assisted copy, design, and SEO baked in.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-deep-lake text-sm font-semibold text-white" aria-hidden="true">3</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Rank</h3>
+                <p class="text-sm text-zinc-700">Pages get optimized, submitted to Google, and start showing up fast.</p>
+              </div>
+            </div>
+            <div class="card p-5 flex items-start gap-4">
+              <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-deep-lake text-sm font-semibold text-white" aria-hidden="true">4</div>
+              <div class="space-y-1">
+                <h3 class="font-semibold text-base text-zinc-900">Calls</h3>
+                <p class="text-sm text-zinc-700">Leads route straight to your phone so you can close the work.</p>
+              </div>
+            </div>
+          </div>
         </section>
 
         <section id="pricing" class="space-y-4">


### PR DESCRIPTION
## Summary
- replace list-based sections on the Lakeshore Local beta page with responsive card grids
- add concise titles and icon placeholders to each card to improve scannability while preserving messaging

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e18576422c83268371668da1ba6cbf