### PR TITLE
Swap selected work placeholders for project imagery

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -218,7 +218,7 @@
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Inkeep+Support" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/inkeep.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Catalog Intelligence UI project for Inkeep showing analytics dashboards" />
         </div>
         <div class="p-6 space-y-3">
@@ -229,7 +229,7 @@
       </article>
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Plain+Case+Study" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/plain.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Headless commerce storefront redesign for Plain with modular product cards" />
         </div>
         <div class="p-6 space-y-3">
@@ -240,7 +240,7 @@
       </article>
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Ekom+Automation" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/ekom.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Ekom operations automation suite dashboard streamlining fulfillment workflows" />
         </div>
         <div class="p-6 space-y-3">

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Inkeep+Support" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/inkeep.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Catalog Intelligence UI project for Inkeep showing analytics dashboards" />
         </div>
         <div class="p-6 space-y-3">
@@ -229,7 +229,7 @@
       </article>
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Plain+Case+Study" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/plain.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Headless commerce storefront redesign for Plain with modular product cards" />
         </div>
         <div class="p-6 space-y-3">
@@ -240,7 +240,7 @@
       </article>
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Ekom+Automation" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/ekom.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Ekom operations automation suite dashboard streamlining fulfillment workflows" />
         </div>
         <div class="p-6 space-y-3">

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch:css": "nodemon -L -e html,js,css --watch public --watch src --exec \"./node_modules/.bin/tailwindcss -i ./src/input.css -o ./public/assets/tailwind.css\"",
     "serve": "./node_modules/.bin/live-server public --open",
     "build": "./node_modules/.bin/tailwindcss -i ./src/input.css -o ./public/assets/tailwind.css --minify",
-    "deploy:gh": "rm -rf docs && mkdir -p docs && npm run build && cp -R public/* docs/ && cp public/index.html ./index.html && rm -rf assets && mkdir -p assets && cp public/assets/tailwind.css assets/tailwind.css && cp public/assets/favicon.svg assets/favicon.svg && rm -rf local && cp -R public/local ./local && git add -A && git commit -m \"deploy\" || true && git push origin main || true"
+    "deploy:gh": "rm -rf docs && mkdir -p docs && npm run build && cp -R public/* docs/ && cp public/index.html ./index.html && rm -rf assets && mkdir -p assets && cp -R public/assets/. assets/ && rm -rf local && cp -R public/local ./local && git add -A && git commit -m \"deploy\" || true && git push origin main || true"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.20",

--- a/public/index.html
+++ b/public/index.html
@@ -218,7 +218,7 @@
     <div class="mt-6 grid gap-6 md:grid-cols-3">
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Inkeep+Support" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/inkeep.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Catalog Intelligence UI project for Inkeep showing analytics dashboards" />
         </div>
         <div class="p-6 space-y-3">
@@ -229,7 +229,7 @@
       </article>
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Plain+Case+Study" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/plain.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Headless commerce storefront redesign for Plain with modular product cards" />
         </div>
         <div class="p-6 space-y-3">
@@ -240,7 +240,7 @@
       </article>
       <article class="card overflow-hidden">
         <div class="aspect-[3/2]">
-          <img src="https://placehold.co/800x533/0f172a/f8fafc?text=Ekom+Automation" class="h-full w-full object-cover" loading="lazy"
+          <img src="assets/images/ekom.webp" class="h-full w-full object-cover" loading="lazy"
             alt="Ekom operations automation suite dashboard streamlining fulfillment workflows" />
         </div>
         <div class="p-6 space-y-3">


### PR DESCRIPTION
## Summary
- replace the Selected Work card thumbnails with the real project webp assets in the site sources and published output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1861e421c8326837df50d17d72335