### PR TITLE
Adjust hero heading emphasis

### DIFF
--- a/local/index.html
+++ b/local/index.html
@@ -57,7 +57,7 @@
       <div class="mx-auto max-w-4xl px-4 pt-20 pb-24 md:pt-28 md:pb-28">
         <div class="max-w-2xl space-y-6">
           <p class="pill">Lakeshore Local Beta</p>
-          <h1 class="font-tight text-4xl md:text-5xl tracking-tight text-deep-lake">Free websites + AI-powered marketing for local businesses</h1>
+          <h1 class="font-tight text-4xl md:text-5xl tracking-tight">Free websites + AI-powered marketing for <span class="text-deep-lake">local businesses</span></h1>
           <p class="text-lg text-zinc-700">We’re testing a new playbook: using AI to build and rank local service websites in days, not months. Our beta partners get everything free while we prove it works.</p>
           <div class="flex flex-wrap items-center gap-3">
             <a class="btn btn-primary" href="mailto:hello@lakeshore.design?subject=Lakeshore%20Local%20Beta">Get Your Free Build</a>


### PR DESCRIPTION
## Summary
- update the local landing page hero heading to use default dark text while highlighting the "local businesses" phrase in blue

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68e1bb19abbc8326bed1e74ad0c4df4a